### PR TITLE
Updates for MacOS 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,12 +45,18 @@ DEPFILE       = Makefile.dep
 #
 uname_O := $(shell sh -c 'uname -o 2>/dev/null || echo not')
 
-ifeq ($(uname_O),Cygwin)
+ifeq ($(uname_O), Cygwin)
 	WIN_CFLAGS = -lpsapi
 	WIN_LFLAGS = -lpsapi
 	WIN_INCDIR = -I./miniposix/
 endif
 
+# system specific variables, add more here
+
+uname_m := $(shell uname -m)
+ifneq ($(uname_m), aarch64)
+	x86_64_CFLAGS = -mfpmath=sse
+endif
 
 # ----------------------------------------------------------------------
 # Compiler
@@ -58,7 +64,7 @@ endif
 
 CC            = gcc
 
-CFLAGS        = -g -w -O3 $(INCDIR) -msse2  -mfpmath=sse $(WIN_CFLAGS)  #-DDEBUG_LOG_ON
+CFLAGS        = -g -w -O3 $(INCDIR) -msse2 $(x86_64_CFLAGS) $(WIN_CFLAGS)  #-DDEBUG_LOG_ON
 
 CXX           = g++
 


### PR DESCRIPTION
Original compilation using clang caused a duplicate symbol error. I changed variable names of the transition and observation matrices in src/Parser/Cassandra/include/pomdp_spec.tab.cc.

I also modified the Makefile to only have the ``-mfpmath=sse`` flag for non-aarch64 architectures. I also thought removing the ``-msse2`` flag would be necessary, but it passed tests and compiled correctly with an M1 chip. If we wish to add in aarch64-linux support, this would likely need to be changed.